### PR TITLE
Document Watching section and extend DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ To reset all user data, run:
 ```bash
 python reset_db.py
 ```
+
+## Watching section
+
+The **Watching** section lets you keep track of TV series you're currently following. From the main menu, click the TV icon to open the list of series. Use **Add Series** to record a new title and **Edit** to update your progress. Your progress is stored in the `watching` table alongside the `people` table.
+
+## Database reset
+
+Running `reset_db.py` now clears both the `people` and `watching` tables.

--- a/app/ui/main_menu.py
+++ b/app/ui/main_menu.py
@@ -23,6 +23,18 @@ class MainMenu(QWidget):
             alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft,
         )
 
+        self.watching_button = QPushButton("\U0001F4FA")  # Unicode TV
+        self.watching_button.setFixedSize(40, 40)
+        self.watching_button.setStyleSheet(
+            "font-size: 18px; border: none; background: transparent;"
+        )
+        self.watching_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.watching_button.clicked.connect(self.open_watching_menu)
+        layout.addWidget(
+            self.watching_button,
+            alignment=Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft,
+        )
+
     def open_people_menu(self):
         main_window = self.window()
 
@@ -33,4 +45,15 @@ class MainMenu(QWidget):
 
         people_menu = PeopleMenu(back_callback=back_to_main_menu, parent=main_window)
         main_window.setCentralWidget(people_menu)
+
+    def open_watching_menu(self):
+        main_window = self.window()
+
+        def back_to_main_menu():
+            main_window.setCentralWidget(MainMenu(parent=main_window))
+
+        from app.ui.watching_menu import WatchingMenu
+
+        menu = WatchingMenu(back_callback=back_to_main_menu, parent=main_window)
+        main_window.setCentralWidget(menu)
 

--- a/app/ui/watching_menu.py
+++ b/app/ui/watching_menu.py
@@ -1,0 +1,129 @@
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QTableWidget, QTableWidgetItem,
+    QPushButton, QHBoxLayout, QLineEdit, QDialog, QFormLayout, QMessageBox
+)
+from PyQt6.QtCore import Qt
+from app.core.people_db import PeopleDB
+
+class WatchingMenu(QWidget):
+    def __init__(self, back_callback, parent=None):
+        super().__init__(parent)
+        self.back_callback = back_callback
+        self.db = PeopleDB()
+        self.init_ui()
+        self.load_series()
+
+    def init_ui(self):
+        layout = QVBoxLayout(self)
+        title = QLabel("Watching")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setStyleSheet("font-size: 24px; font-weight: bold;")
+        layout.addWidget(title)
+
+        self.table = QTableWidget(0, 3)
+        self.table.setHorizontalHeaderLabels(["ID", "Series", "Progress"])
+        self.table.setSelectionBehavior(self.table.SelectionBehavior.SelectRows)
+        self.table.setEditTriggers(self.table.EditTrigger.NoEditTriggers)
+        layout.addWidget(self.table)
+
+        buttons = QHBoxLayout()
+        self.add_button = QPushButton("Add Series")
+        self.add_button.clicked.connect(self.add_series)
+        buttons.addWidget(self.add_button)
+
+        self.edit_button = QPushButton("Edit Progress")
+        self.edit_button.clicked.connect(self.edit_progress)
+        buttons.addWidget(self.edit_button)
+
+        self.delete_button = QPushButton("Delete Series")
+        self.delete_button.clicked.connect(self.delete_series)
+        buttons.addWidget(self.delete_button)
+
+        self.back_button = QPushButton("Back")
+        self.back_button.clicked.connect(self.go_back)
+        buttons.addWidget(self.back_button)
+
+        layout.addLayout(buttons)
+
+    def load_series(self):
+        shows = self.db.get_watching()
+        self.table.setRowCount(0)
+        for show in shows:
+            row = self.table.rowCount()
+            self.table.insertRow(row)
+            self.table.setItem(row, 0, QTableWidgetItem(str(show[0])))
+            self.table.setItem(row, 1, QTableWidgetItem(show[1]))
+            self.table.setItem(row, 2, QTableWidgetItem(str(show[2])))
+        self.table.resizeColumnsToContents()
+
+    def add_series(self):
+        dialog = SeriesDialog()
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            title = dialog.title_field.text().strip()
+            if title:
+                self.db.add_series(title)
+                self.load_series()
+            else:
+                QMessageBox.warning(self, "Input Error", "Title cannot be empty.")
+
+    def edit_progress(self):
+        selected = self.table.selectedItems()
+        if not selected:
+            QMessageBox.warning(self, "Selection Error", "Please select a series to edit.")
+            return
+        row = self.table.currentRow()
+        series_id = int(self.table.item(row, 0).text())
+        current_title = self.table.item(row, 1).text()
+        current_progress = self.table.item(row, 2).text()
+        dialog = SeriesDialog(current_title, current_progress)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            progress_text = dialog.progress_field.text().strip()
+            try:
+                progress_val = int(progress_text)
+            except ValueError:
+                QMessageBox.warning(self, "Input Error", "Progress must be a number.")
+                return
+            self.db.update_progress(series_id, progress_val)
+            self.load_series()
+
+    def delete_series(self):
+        selected = self.table.selectedItems()
+        if not selected:
+            QMessageBox.warning(self, "Selection Error", "Please select a series to delete.")
+            return
+        row = self.table.currentRow()
+        series_id = int(self.table.item(row, 0).text())
+        reply = QMessageBox.question(
+            self,
+            "Delete Series",
+            f"Are you sure you want to delete the series with ID {series_id}?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self.db.delete_series(series_id)
+            self.load_series()
+
+    def go_back(self):
+        self.db.close()
+        self.back_callback()
+
+class SeriesDialog(QDialog):
+    def __init__(self, title="", progress="", parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Series Details")
+        self.setModal(True)
+        self.title_field = QLineEdit(title)
+        self.progress_field = QLineEdit(progress)
+        form = QFormLayout(self)
+        form.addRow("Series:", self.title_field)
+        form.addRow("Progress:", self.progress_field)
+
+        buttons = QHBoxLayout()
+        ok = QPushButton("OK")
+        ok.clicked.connect(self.accept)
+        buttons.addWidget(ok)
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        buttons.addWidget(cancel)
+        form.addRow(buttons)
+

--- a/reset_db.py
+++ b/reset_db.py
@@ -4,4 +4,4 @@ if __name__ == "__main__":
     db = PeopleDB()
     db.reset_database()
     db.close()
-    print("Database has been reset.")
+    print("Database tables 'people' and 'watching' have been reset.")

--- a/tests/test_people_db.py
+++ b/tests/test_people_db.py
@@ -27,3 +27,30 @@ def test_add_retrieve_delete(tmp_path):
         assert db.get_people() == []
     finally:
         db.close()
+
+
+def test_add_series_update_progress(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = PeopleDB(db_path=str(db_path))
+    try:
+        # Initially watching table should be empty
+        assert db.get_watching() == []
+
+        # Add a series
+        db.add_series("Test Show")
+        shows = db.get_watching()
+        assert len(shows) == 1
+        show_id, title, progress = shows[0]
+        assert title == "Test Show"
+        assert progress == 0
+
+        # Update progress
+        db.update_progress(show_id, 5)
+        updated = db.get_watching()[0]
+        assert updated[2] == 5
+
+        # Delete the series and ensure table is empty again
+        db.delete_series(show_id)
+        assert db.get_watching() == []
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- document the new Watching section in README
- support a `watching` table alongside `people`
- provide CRUD helpers for series management
- expose a Watching menu from the main menu
- update tests for watching features
- refine database reset message

## Testing
- `pytest -q`
